### PR TITLE
fix: prevent provider field reset when updating unrelated service fields

### DIFF
--- a/src/actions/service/index.ts
+++ b/src/actions/service/index.ts
@@ -402,7 +402,9 @@ export const updateServiceAction = protectedClient
       collection: 'services',
       data: {
         ...data,
-        provider: data?.provider ?? null,
+        provider:
+          (data?.providerType ? data?.provider : previousDetails.provider) ??
+          null,
       },
       id,
       depth: 3,


### PR DESCRIPTION
### Issue
The `provider` field was being reset to `null` whenever updating service fields from tabs other than the General tab (e.g., Environment or Switch Service settings). This caused to lose the provider configuration when saving environment variables or switching services between projects.

### To reproduce
1. Go to a service's General tab
2. Set up the GitHub provider, using automatic deployment
3. Save the General settings
4. Navigate to Environment tab
5. Add/modify environment variables
6. Save the Environment settings
7. Navigate back to General tab

💥 The GitHub provider setting has been reset to "without automatic deployment".
