### PR TITLE
fix(ui): use consistent layout for GitHub deployment options

### DIFF
--- a/src/components/SidebarToggleButton.tsx
+++ b/src/components/SidebarToggleButton.tsx
@@ -23,7 +23,7 @@ const SidebarToggleButton = ({
       variant='link'
       size='icon'
       type='button'
-      className='text-sm text-primary'>
+      className='text-primary -my-4 text-sm'>
       <Info />
     </Button>
   )

--- a/src/components/service/DockerForm.tsx
+++ b/src/components/service/DockerForm.tsx
@@ -204,7 +204,7 @@ const DockerForm = ({
           </div>
 
           <div className='space-y-2'>
-            <Label className='block'>
+            <Label className='flex'>
               Ports
               <SidebarToggleButton
                 directory='services'

--- a/src/components/service/VariablesForm.tsx
+++ b/src/components/service/VariablesForm.tsx
@@ -609,7 +609,7 @@ const VariablesForm = ({ service }: { service: Service }) => {
             {fields.length ? (
               <div className='text-muted-foreground grid grid-cols-[1fr_1fr_2.5rem] gap-4 text-sm'>
                 <p className='font-semibold'>Key</p>
-                <p className='font-semibold'>
+                <p className='flex items-center font-semibold'>
                   Value{' '}
                   <SidebarToggleButton
                     directory='services'

--- a/src/components/service/git/GithubForm.tsx
+++ b/src/components/service/git/GithubForm.tsx
@@ -393,7 +393,7 @@ const GithubForm = ({
                 control={form.control}
                 name='provider'
                 render={({ field }) => (
-                  <FormItem className='-mt-2'>
+                  <FormItem>
                     <FormControl>
                       <SelectSearch
                         fieldValue={field.value}
@@ -511,7 +511,7 @@ const GithubForm = ({
             </div>
 
             <div className='grid gap-4 md:grid-cols-4'>
-              <div className='mt-2 md:col-span-2'>
+              <div className='md:col-span-2'>
                 {/* Branch field */}
                 <FormField
                   control={form.control}

--- a/src/components/service/git/GithubForm.tsx
+++ b/src/components/service/git/GithubForm.tsx
@@ -536,32 +536,6 @@ const GithubForm = ({
             />
 
             <div className='grid gap-4 md:grid-cols-2'>
-              {/* Build path */}
-              <FormField
-                control={form.control}
-                name='githubSettings.buildPath'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      Build path{' '}
-                      <SidebarToggleButton
-                        directory='services'
-                        fileName='app-service'
-                        sectionId='#build-path--editable'
-                      />
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        value={field.value || ''}
-                        onChange={handleBuildPathInputChange(field.onChange)}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
               {/* Port field */}
               <FormField
                 control={form.control}
@@ -587,6 +561,32 @@ const GithubForm = ({
                             : ''
                           field.onChange(value)
                         }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Build path */}
+              <FormField
+                control={form.control}
+                name='githubSettings.buildPath'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Build path{' '}
+                      <SidebarToggleButton
+                        directory='services'
+                        fileName='app-service'
+                        sectionId='#build-path--editable'
+                      />
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value || ''}
+                        onChange={handleBuildPathInputChange(field.onChange)}
                       />
                     </FormControl>
                     <FormMessage />


### PR DESCRIPTION
This PR improves the UI consistency of the GitHub deployment options. The `SidebarToggleButton` alignment fix (negative margin) has been validated across all usage contexts and I think that provides better visual alignment.

Before:
![before](https://github.com/user-attachments/assets/a7470eb1-a76e-4c74-95ba-880c7933d743)

After:
![after](https://github.com/user-attachments/assets/8c2ebff9-9269-4a22-b3e9-846053c673ba)

> **Note for reviewers:** Please review with "Ignore whitespace" option enabled to focus on the actual code changes.